### PR TITLE
plone.keyring requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
-        'plone.keyring > 1.0',
+        'plone.keyring >= 3.0dev',
         'zope.component',
         'zope.interface',
         'Zope2',


### PR DESCRIPTION
Trying latest CSRF protection on Plone 4.2 I found that the requirement is changed: `plone.keyring` version needs the `ramdom` method.
