### PR TITLE
Add ITransform.transformBytes for protect transform to fix compatibility

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,9 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Add ITransform.transformBytes for protect transform to fix compatibility
+  with plone.app.blocks' ESI-rendering
+  [atsoukka]
 
 3.0.1 (2014-11-01)
 ------------------

--- a/plone/protect/auto.py
+++ b/plone/protect/auto.py
@@ -68,6 +68,10 @@ class ProtectTransform(object):
                         'token to response for url %s' % self.request.URL)
             return None
 
+    def transformBytes(self, result, encoding):
+        result = unicode(result, encoding, 'ignore')
+        return self.transformIterable([result], encoding)
+
     def transformString(self, result, encoding):
         return self.transformIterable([result], encoding)
 


### PR DESCRIPTION
To fix compatibility with plone.app.blocks' ESI-rendering.

ESI transform must be the only transform, which returns bytes, and because Protect transform comes after that, it breaks blocks' ESI rendering on Plone 5.

The real reason, why ESI transform returns bytes, is that the ESI helpers in plone.tiles are implemented to work on bytestrings
https://github.com/plone/plone.tiles/blob/master/plone/tiles/esi.py

/cc https://github.com/plone/plone.app.blocks/issues/15