### PR TITLE
fix pluggable auth CSRF warnings on zope root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- fix pluggable auth CSRF warnings on zope root. Very difficult to reproduce.
+  Just let plone.protect do it's job also on zope root
+  [vangheem]
 
 
 3.0.6 (2015-07-20)

--- a/plone/protect/configure.zcml
+++ b/plone/protect/configure.zcml
@@ -65,14 +65,12 @@
         class="Products.PluggableAuthService.utils"
         original="getCSRFToken"
         replacement=".monkey.pluggableauth__getCSRFToken"
-        preserveOriginal="True"
         />
     <monkey:patch
         description="Patch old pluggable auth to use plone mechanism"
         class="Products.PluggableAuthService.utils"
         original="checkCSRFToken"
         replacement=".monkey.pluggableauth__checkCSRFToken"
-        preserveOriginal="True"
         />
 
 </configure>

--- a/plone/protect/monkey.py
+++ b/plone/protect/monkey.py
@@ -1,7 +1,5 @@
-from zope.component.hooks import getSite
 from urlparse import urlparse, urljoin
 from plone.protect.auto import safeWrite
-from Products.PluggableAuthService import utils as pluaggable_utils
 
 
 def RedirectTo__call__(self, controller_state):
@@ -43,17 +41,13 @@ def wl_lockmapping(self, killinvalids=0, create=0):
 
 def pluggableauth__getCSRFToken(request):
     """
-    if we have a site object, let plone.protect do it's job
+    let plone.protect do it's job
     """
-    if getSite():
-        return
-    return pluaggable_utils._old_getCSRFToken(request)
+    return ''
 
 
 def pluggableauth__checkCSRFToken(request, token='csrf_token', raises=True):
     """
-    if we have a site object, let plone.protect do it's job
+    let plone.protect do it's job
     """
-    if getSite():
-        return
-    return pluaggable_utils._old_checkCSRFToken(request)
+    pass


### PR DESCRIPTION

  Just let plone.protect do it's job also on zope root