### PR TITLE
Show title and description in @@confirm-action view, disable editable border

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.0.15 (unreleased)
 -------------------
 
+- Disable editable border for @@confirm-action view.
+  [lgraf]
+
 - Make title and description show up on @@confirm-action view.
   [lgraf]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.0.15 (unreleased)
 -------------------
 
+- Make title and description show up on @@confirm-action view.
+  [lgraf]
+
 - Allow views to override 'X-Frame-Options' by setting the response header
   manually.
   [alecm]

--- a/plone/protect/confirm.pt
+++ b/plone/protect/confirm.pt
@@ -6,13 +6,13 @@
       metal:use-macro="context/main_template/macros/master"
       i18n:domain="plone">
 <body>
-  <metal:title define-slot="content-title">
+  <metal:title fill-slot="content-title">
      <h1 class="documentFirstHeading">
          Confirming User Action.
      </h1>
   </metal:title>
 
-  <metal:description define-slot="content-description">
+  <metal:description fill-slot="content-description">
      <div class="documentDescription">
          Confirm that you'd like to perform this action.
      </div>

--- a/plone/protect/confirm.pt
+++ b/plone/protect/confirm.pt
@@ -5,6 +5,10 @@
       lang="en"
       metal:use-macro="context/main_template/macros/master"
       i18n:domain="plone">
+
+<metal:block fill-slot="top_slot"
+             tal:define="dummy python:request.set('disable_border', 1)" />
+
 <body>
   <metal:title fill-slot="content-title">
      <h1 class="documentFirstHeading">


### PR DESCRIPTION
- Makes title and description actually show up (using `fill-slot` instead of `define-slot`)
- Disables editable border

### Plone 5

#### Before

![confirm_plone5_before](https://cloud.githubusercontent.com/assets/405124/10440480/d4e175be-713f-11e5-9f30-a0d0fbfd4b30.png)

#### After

![confirm_plone5_after](https://cloud.githubusercontent.com/assets/405124/10440483/dbf70684-713f-11e5-9bed-7bef51b992ed.png)

---

### Plone 4

#### Before

![confirm_plone4_before](https://cloud.githubusercontent.com/assets/405124/10440018/31976432-713e-11e5-83ca-f0a08fa1d36e.png)

#### After

![confirm_plone4_after](https://cloud.githubusercontent.com/assets/405124/10440021/37918598-713e-11e5-9a96-9bed7ae2bdd9.png)
