### PR TITLE
Make sure transforms don't fail on redirects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*"
+- Make sure transforms don't fail on redirects.
+  [lgraf]
 
 
 3.0.15 (2015-10-30)

--- a/plone/protect/auto.py
+++ b/plone/protect/auto.py
@@ -67,10 +67,10 @@ class ProtectTransform(object):
         self.request = request
 
     def parseTree(self, result, encoding):
-        # if it's a redirect, the result is empty
+        # if it's a redirect, the result shall not be transformed
         request = getRequest()
         if request.response.status in (301, 302):
-            return result
+            return None
 
         if isinstance(result, XMLSerializer):
             return result


### PR DESCRIPTION
The handling for redirects introduced in @6348b574 leads to this traceback when a redirect is encountered:

```pytb
2015-11-02 11:58:49 ERROR plone.transformchain Unexpected error whilst trying to apply transform chain
Traceback (most recent call last):
  File "/Users/lukasgraf/Plone/eggs/plone.transformchain-1.0.4-py2.7.egg/plone/transformchain/transformer.py", line 48, in __call__
    newResult = handler.transformIterable(result, encoding)
  File "/Users/lukasgraf/Plone/buildouts/plone/plone4/src/plone.protect/plone/protect/auto.py", line 163, in transformIterable
    return self.transform(result, encoding)
  File "/Users/lukasgraf/Plone/buildouts/plone/plone4/src/plone.protect/plone/protect/auto.py", line 267, in transform
    root = result.tree.getroot()
AttributeError: 'list' object has no attribute 'tree'
```

This is because [`ProtectTransform.parseTree()` returns `result` unchanged](https://github.com/plone/plone.protect/blob/3.0.15/plone/protect/auto.py#L71-L73), which may be a list or a string.

But [`ProtectTransform.transform()` expects it to be either `None` or an `XMLSerializer` object](https://github.com/plone/plone.protect/blob/3.0.15/plone/protect/auto.py#L265-L267).

Returning `None` instead from `parseTree()` for redirects would be the proper thing to do IMHO. This should cause `transform()` to also return `None`, indicating that no transformation should be done.

Tested on Plone 4.3.7 + `plone4.csrffixes`.

@gforcada @vangheem 