### PR TITLE
fullfil Plone Styleguide Coding Conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig Settings (http://EditorConfig.org)
+
+# top-most EditorConfig file
+root = false
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{*.py,*.cfg}]
+indent_size = 4
+
+[{*.html,*.dtml,*.pt,*.zpt,*.xml,*.zcml,*.js,*.yml,*.json}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ New:
 
   [loechel]
 
+
 Fixes:
 
 - Use zope.interface decorator.
@@ -29,8 +30,6 @@ Fixes:
 
 3.0.18 (2016-02-25)
 -------------------
-
-- *add item here*
 
 Fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,14 +11,26 @@ New:
   Fixes https://github.com/plone/plone.protect/issues/42
   [maurits]
 
+- include a setup.cfg and a .editorconfig file with code conventions:
+
+  - settings for isort
+  - plone styleguide settings
+
+  [loechel]
+
 Fixes:
 
 - Use zope.interface decorator.
   [gforcada]
 
+- Apply code conventions.
+  [loechel]
+
 
 3.0.18 (2016-02-25)
 -------------------
+
+- *add item here*
 
 Fixes:
 

--- a/plone/__init__.py
+++ b/plone/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
 try:
     __import__('pkg_resources').declare_namespace(__name__)

--- a/plone/protect/__init__.py
+++ b/plone/protect/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.protect.authenticator import check as CheckAuthenticator
 from plone.protect.authenticator import createToken
 from plone.protect.authenticator import CustomCheckAuthenticator

--- a/plone/protect/__init__.py
+++ b/plone/protect/__init__.py
@@ -1,5 +1,5 @@
-from plone.protect.utils import protect
 from plone.protect.authenticator import check as CheckAuthenticator
-from plone.protect.postonly import check as PostOnly
-from plone.protect.authenticator import CustomCheckAuthenticator
 from plone.protect.authenticator import createToken
+from plone.protect.authenticator import CustomCheckAuthenticator
+from plone.protect.postonly import check as PostOnly
+from plone.protect.utils import protect

--- a/plone/protect/authenticator.py
+++ b/plone/protect/authenticator.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from AccessControl import getSecurityManager
 from plone.keyring.interfaces import IKeyManager
 from plone.protect.interfaces import IAuthenticatorView

--- a/plone/protect/authenticator.py
+++ b/plone/protect/authenticator.py
@@ -8,6 +8,8 @@ from zope.interface import implementer
 from ZPublisher.HTTPRequest import HTTPRequest
 
 import hmac
+
+
 try:
     from hashlib import sha1 as sha
 except ImportError:

--- a/plone/protect/interfaces.py
+++ b/plone/protect/interfaces.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from zope.interface import Interface
 
 

--- a/plone/protect/monkey.py
+++ b/plone/protect/monkey.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.protect.auto import safeWrite
 from Products.PluggableAuthService import utils as pluggable_utils
 from urlparse import urljoin

--- a/plone/protect/monkey.py
+++ b/plone/protect/monkey.py
@@ -1,7 +1,9 @@
-from urlparse import urlparse, urljoin
 from plone.protect.auto import safeWrite
-import inspect
 from Products.PluggableAuthService import utils as pluggable_utils
+from urlparse import urljoin
+from urlparse import urlparse
+
+import inspect
 
 
 def RedirectTo__call__(self, controller_state):

--- a/plone/protect/postonly.py
+++ b/plone/protect/postonly.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from zExceptions import Forbidden
 from ZPublisher.HTTPRequest import HTTPRequest
 

--- a/plone/protect/subscribers.py
+++ b/plone/protect/subscribers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.keyring.interfaces import IKeyManager
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.protect.utils import getRoot

--- a/plone/protect/subscribers.py
+++ b/plone/protect/subscribers.py
@@ -1,20 +1,22 @@
+from plone.keyring.interfaces import IKeyManager
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.protect.utils import getRoot
+from plone.protect.utils import getRootKeyManager
+from Products.PluggableAuthService.interfaces.events import IUserLoggedInEvent
+from zope.component import adapter
+from zope.component import ComponentLookupError
+from zope.component import getUtility
+from zope.globalrequest import getRequest
+from zope.interface import alsoProvides
+
 import logging
 import time
 
-from Products.PluggableAuthService.interfaces.events import IUserLoggedInEvent
-from plone.keyring.interfaces import IKeyManager
-from plone.protect.interfaces import IDisableCSRFProtection
-from zope.component import ComponentLookupError
-from zope.component import adapter
-from zope.component import getUtility
+
 try:
     from zope.component.hooks import getSite
 except ImportError:
     from zope.app.component.hooks import getSite
-from zope.globalrequest import getRequest
-from zope.interface import alsoProvides
-from plone.protect.utils import getRootKeyManager
-from plone.protect.utils import getRoot
 
 
 LOGGER = logging.getLogger('plone.protect')

--- a/plone/protect/testing.py
+++ b/plone/protect/testing.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.app.testing import applyProfile
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer

--- a/plone/protect/testing.py
+++ b/plone/protect/testing.py
@@ -1,9 +1,9 @@
-from Products.Five import BrowserView
+from plone.app.testing import applyProfile
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
 from plone.app.testing.layers import FunctionalTesting
 from plone.protect.auto import safeWrite
+from Products.Five import BrowserView
 from zope.configuration import xmlconfig
 
 

--- a/plone/protect/tests/__init__.py
+++ b/plone/protect/tests/__init__.py
@@ -1,1 +1,2 @@
+# -*- coding: utf-8 -*-
 # Poof

--- a/plone/protect/tests/case.py
+++ b/plone/protect/tests/case.py
@@ -1,10 +1,10 @@
-from unittest import TestCase
-from zope.component import getGlobalSiteManager
-from plone.keyring.interfaces import IKeyManager
 from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import noSecurityManager
 from AccessControl.User import User
+from plone.keyring.interfaces import IKeyManager
 from plone.keyring.keymanager import KeyManager
+from unittest import TestCase
+from zope.component import getGlobalSiteManager
 
 
 class MockRequest(dict):

--- a/plone/protect/tests/case.py
+++ b/plone/protect/tests/case.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import noSecurityManager
 from AccessControl.User import User

--- a/plone/protect/tests/testAuthenticator.py
+++ b/plone/protect/tests/testAuthenticator.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from AccessControl import getSecurityManager
 from plone.protect import createToken
 from plone.protect import CustomCheckAuthenticator

--- a/plone/protect/tests/testAuthenticator.py
+++ b/plone/protect/tests/testAuthenticator.py
@@ -1,17 +1,19 @@
-import hmac
-import sys
-from unittest import TestSuite
-from unittest import makeSuite
 from AccessControl import getSecurityManager
-from zExceptions import Forbidden
-from ZPublisher.HTTPRequest import HTTPRequest
-from plone.protect.tests.case import KeyringTestCase
-from plone.protect.tests.case import MockRequest
+from plone.protect import createToken
+from plone.protect import CustomCheckAuthenticator
+from plone.protect import protect
 from plone.protect.authenticator import AuthenticatorView
 from plone.protect.authenticator import check
-from plone.protect import protect
-from plone.protect import CustomCheckAuthenticator
-from plone.protect import createToken
+from plone.protect.tests.case import KeyringTestCase
+from plone.protect.tests.case import MockRequest
+from unittest import makeSuite
+from unittest import TestSuite
+from zExceptions import Forbidden
+from ZPublisher.HTTPRequest import HTTPRequest
+
+import hmac
+import sys
+
 
 try:
     from hashlib import sha1 as sha

--- a/plone/protect/tests/testAuto.py
+++ b/plone/protect/tests/testAuto.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.app.testing import login
 from plone.app.testing import logout
 from plone.app.testing import SITE_OWNER_NAME

--- a/plone/protect/tests/testAuto.py
+++ b/plone/protect/tests/testAuto.py
@@ -1,9 +1,9 @@
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import TEST_USER_PASSWORD
-from plone.app.testing import SITE_OWNER_NAME
-from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import login
 from plone.app.testing import logout
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
 from plone.keyring.interfaces import IKeyManager
 from plone.protect import createToken
 from plone.protect.authenticator import AuthenticatorView
@@ -11,10 +11,11 @@ from plone.protect.auto import ProtectTransform
 from plone.protect.auto import safeWrite
 from plone.protect.testing import PROTECT_FUNCTIONAL_TESTING
 from plone.testing.z2 import Browser
-import transaction
-import unittest2 as unittest
 from zExceptions import Forbidden
 from zope.component import getUtility
+
+import transaction
+import unittest2 as unittest
 
 
 class _BaseAutoTest(object):

--- a/plone/protect/tests/testPatches.py
+++ b/plone/protect/tests/testPatches.py
@@ -2,6 +2,7 @@ from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.protect.testing import PROTECT_FUNCTIONAL_TESTING
 from plone.testing.z2 import Browser
+
 import unittest2 as unittest
 
 

--- a/plone/protect/tests/testPatches.py
+++ b/plone/protect/tests/testPatches.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.protect.testing import PROTECT_FUNCTIONAL_TESTING

--- a/plone/protect/tests/testPostOnly.py
+++ b/plone/protect/tests/testPostOnly.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.protect.postonly import check
 from unittest import makeSuite
 from unittest import TestCase

--- a/plone/protect/tests/testPostOnly.py
+++ b/plone/protect/tests/testPostOnly.py
@@ -1,9 +1,9 @@
+from plone.protect.postonly import check
+from unittest import makeSuite
 from unittest import TestCase
 from unittest import TestSuite
-from unittest import makeSuite
-from plone.protect.postonly import check
-from ZPublisher.HTTPRequest import HTTPRequest
 from zExceptions import Forbidden
+from ZPublisher.HTTPRequest import HTTPRequest
 
 
 class PostOnlyTests(TestCase):

--- a/plone/protect/tests/testUtils.py
+++ b/plone/protect/tests/testUtils.py
@@ -1,9 +1,11 @@
+from plone.protect.testing import PROTECT_FUNCTIONAL_TESTING
+from plone.protect.utils import addTokenToUrl
+from plone.protect.utils import protect
+from unittest import makeSuite
 from unittest import TestCase
 from unittest import TestSuite
-from unittest import makeSuite
-from plone.protect.utils import protect, addTokenToUrl
+
 import unittest2 as unittest
-from plone.protect.testing import PROTECT_FUNCTIONAL_TESTING
 
 
 def funcWithoutRequest():

--- a/plone/protect/tests/testUtils.py
+++ b/plone/protect/tests/testUtils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.protect.testing import PROTECT_FUNCTIONAL_TESTING
 from plone.protect.utils import addTokenToUrl
 from plone.protect.utils import protect

--- a/plone/protect/utils.py
+++ b/plone/protect/utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from AccessControl.requestmethod import _buildFacade
 from Acquisition import aq_parent
 from OFS.interfaces import IApplication

--- a/plone/protect/utils.py
+++ b/plone/protect/utils.py
@@ -1,12 +1,13 @@
-import inspect
-import logging
-from Acquisition import aq_parent
 from AccessControl.requestmethod import _buildFacade
+from Acquisition import aq_parent
+from OFS.interfaces import IApplication
 from plone.keyring.keymanager import KeyManager
 from plone.protect.authenticator import createToken
 from zope.globalrequest import getRequest
 
-from OFS.interfaces import IApplication
+import inspect
+import logging
+
 
 SAFE_WRITE_KEY = 'plone.protect.safe_oids'
 LOGGER = logging.getLogger('plone.protect')

--- a/plone/protect/views.py
+++ b/plone/protect/views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.protect.interfaces import IConfirmView
 from Products.Five import BrowserView
 from zope.interface import implementer

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[isort]
+force_alphabetical_sort=True
+force_single_line=True
+force_to_top=True
+from_first=True
+lines_after_imports=2
+line_length=200
+not_skip=__init__.py

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from setuptools import setup, find_packages
+# -*- coding: utf-8 -*-
+from setuptools import find_packages
+from setuptools import setup
+
 
 version = '3.0.19.dev0'
 


### PR DESCRIPTION
Various Changes, due to a fix for disabling transforms on request while CSRF Protection should be disabled.
- Cleanup of package, to fullfil Plone Styleguide Coding Conventions
- Files Added for Styleguide Settings:
  - setup.cfg - isort settings
  - .editorconfig
- ~~modified PloneTransform.transformIteratable (auto.py) to disable transform if CSRF Protection is explicite disabled.~~
