### PR TITLE
Test request missing environ

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fixed AttributeError when calling ``safeWrite`` on a
+  ``TestRequest``, because this has no ``environ.``.  [maurits]
 
 
 3.0.17 (2015-12-07)

--- a/plone/protect/auto.py
+++ b/plone/protect/auto.py
@@ -213,7 +213,7 @@ class ProtectTransform(object):
                 # need to be portlet assignments. XXX needs to be fixed
                 # somehow...
                 safe_oids = []
-                if SAFE_WRITE_KEY in self.request.environ:
+                if SAFE_WRITE_KEY in getattr(self.request, 'environ', {}):
                     safe_oids = self.request.environ[SAFE_WRITE_KEY]
                 safe = True
                 for obj in registered:

--- a/plone/protect/utils.py
+++ b/plone/protect/utils.py
@@ -71,14 +71,19 @@ def addTokenToUrl(url, req=None, manager=None):
         return url
     if req is None:
         req = getRequest()
-    if not url.startswith(req.SERVER_URL):
+    if req is None or not url.startswith(req.SERVER_URL):
         # only transforms urls to same site
         return url
-    if '_auth_token' not in req.environ:
-        # let's cache this value since this could be called
-        # many times for one request
-        req.environ['_auth_token'] = createToken(manager=manager)
-    token = req.environ['_auth_token']
+    if getattr(req, 'environ', _default) is _default:
+        # TestRequests have no environ.
+        token = createToken(manager=manager)
+    elif '_auth_token' not in req.environ:
+        # Let's cache this value since this could be called
+        # many times for one request.
+        token = createToken(manager=manager)
+        req.environ['_auth_token'] = token
+    else:
+        token = req.environ['_auth_token']
 
     if '_authenticator' not in url:
         if '?' not in url:

--- a/plone/protect/utils.py
+++ b/plone/protect/utils.py
@@ -110,7 +110,8 @@ def getRoot(context):
 def safeWrite(obj, request=None):
     if request is None:
         request = getRequest()
-    if request is None:
+    if request is None or getattr(request, 'environ', _default) is _default:
+        # Request not found or it is a TestRequest without an environment.
         LOGGER.debug('could not mark object as a safe write')
         return
     if SAFE_WRITE_KEY not in request.environ:


### PR DESCRIPTION
With https://github.com/plone/plone.contentrules/pull/4, which tries to fix a few write-on-read failures, we get errors like this:

```
'TestRequest' object has no attribute 'environ'
```

See for example:
http://jenkins.plone.org/job/pull-request-5.0/941/testReport/junit/plone.app.z3cform.tests.test_objectsubform/TestObjectSubForm/test_closest_content/

This pull request fixes this, plus a few more spots where this could happen though I did not see it yet.