### PR TITLE
Add forward compatibility for auto protection in the 2.x branch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
+- Added ``token`` to ``@@authenticator`` view.  For forward
+  compatibility with plone.protect 3.  [maurits]
+
 - Added ``plone.protect.interfaces.IDisableCSRFProtection`` from
   plone.protect 3.  It has no effect in this version.  It is only here
   to avoid having to do conditional imports when you want to disable

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,10 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added ``plone.protect.interfaces.IDisableCSRFProtection`` from
+  plone.protect 3.  It has no effect in this version.  It is only here
+  to avoid having to do conditional imports when you want to disable
+  csrf protection that is not actually in this version.  [maurits]
 
 
 2.0.2 (2012-12-09)

--- a/plone/protect/authenticator.py
+++ b/plone/protect/authenticator.py
@@ -64,6 +64,9 @@ def createToken(extra=''):
 class AuthenticatorView(BrowserView):
     implements(IAuthenticatorView)
 
+    def token(self, extra=''):
+        return createToken(extra)
+
     def authenticator(self, extra='', name='_authenticator'):
         auth = createToken(extra)
         return '<input type="hidden" name="%s" value="%s"/>' % (

--- a/plone/protect/interfaces.py
+++ b/plone/protect/interfaces.py
@@ -13,3 +13,20 @@ class IAuthenticatorView(Interface):
         """
         Verify if the request contains a valid authenticator.
         """
+
+
+class IDisableCSRFProtection(Interface):
+    """Be able to disable on a per-request basis.
+
+    In this version of plone.protect it does nothing.
+
+    Forward port from plone.protect 3, so you do not need code like this
+    when you want to disable csrf protection:
+
+        try:
+            from plone.protect.interfaces import IDisableCSRFProtection
+        except ImportError:
+            IDisableCSRFProtection = None
+        if IDisableCSRFProtection is not None:
+            alsoProvides(request, IDisableCSRFProtection)
+    """

--- a/plone/protect/interfaces.py
+++ b/plone/protect/interfaces.py
@@ -3,6 +3,9 @@ from zope.interface import Interface
 
 class IAuthenticatorView(Interface):
 
+    def token():
+        """return token value"""
+
     def authenticator():
         """Return an xhtml snippet which sets an authenticator.
 


### PR DESCRIPTION
I though I had created a pull request already, but I was wrong.
This is needed for https://github.com/plone/buildout.coredev/pull/176 and is tested there. Plone 4.3 only.

This does ** not** add auto csrf protection. But it makes it easier to write code that works with both 2.x and 3.x. Put simply, it makes sure that trying to disable auto csrf protection on 2.x (which does not have it) does not fail.