### PR TITLE
Added protect.js from plone4.csrffixes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,10 @@ Changelog
 
 New:
 
-- *add item here*
+- Added protect.js from plone4.csrffixes.  This adds an ``X-CSRF-TOKEN``
+  header to ajax requests.
+  Fixes https://github.com/plone/plone.protect/issues/42
+  [maurits]
 
 Fixes:
 

--- a/plone/protect/auto.py
+++ b/plone/protect/auto.py
@@ -298,4 +298,18 @@ class ProtectTransform(object):
                 hidden.attrib['value'] = token
                 form.append(hidden)
 
+        if self.site is not None and not root.cssselect('#protect-script'):
+            # Alternative: add this in the resource registry.
+            site_url = self.site.absolute_url()
+            body = root.cssselect('body')[0]
+            protect_script = etree.Element("script")
+            protect_script.attrib.update({
+                'type': "application/javascript",
+                'src': "%s/++resource++protect.js" % site_url,
+                'data-site-url': site_url,
+                'data-token': token,
+                'id': 'protect-script'
+            })
+            body.append(protect_script)
+
         return result

--- a/plone/protect/configure.zcml
+++ b/plone/protect/configure.zcml
@@ -35,6 +35,11 @@
         factory=".auto.ProtectTransform"
         />
 
+    <browser:resource
+        name="protect.js"
+        file="protect.js"
+        />
+
     <browser:page
         name="confirm-action"
         for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/plone/protect/protect.js
+++ b/plone/protect/protect.js
@@ -1,0 +1,85 @@
+/* jshint undef: true, unused: true */
+/* globals tinymce, jQuery, kukit */
+
+"use strict";
+
+var script = document.getElementById('protect-script');
+
+if(script){
+  var base_url = script.getAttribute('data-site-url');
+  var token = script.getAttribute('data-token');
+
+  if(window.jQuery !== undefined){
+    jQuery.ajaxSetup({
+      beforeSend: function (xhr, options){
+        if(options === undefined){
+          return;
+        }
+        if(!options.url){
+          return;
+        }
+        if(options.url.indexOf('_authenticator') !== -1){
+          return;
+        }
+        if(options.url.indexOf(base_url) === 0 || options.url.indexOf('//') === -1){
+          // only urls that start with the site url
+          // Extra compared to plone4.csrffixes: also for relative urls, like @@my-view.
+          xhr.setRequestHeader("X-CSRF-TOKEN", token);
+        }
+      }
+    });
+  }
+  if(window.tinymce && window.tinymce.util.XHR._send === undefined){
+    window.tinymce.util.XHR._send = window.tinymce.util.XHR.send;
+    var xhr = window.tinymce.util.XHR;
+    var _send = xhr.send;
+    window.tinymce.util.XHR.send = function(){
+      var args = Array.prototype.slice.call(arguments);
+      if(args[0]){
+        var config = args[0];
+        if(config.data && typeof(config.data) === 'string' &&
+            config.url && config.url.indexOf(base_url) === 0){
+          config.data = config.data + '&_authenticator=' + token;
+        }
+      }
+     _send.apply(xhr, args);
+    };
+  }
+  if(window.kukit && window.kukit.sa){
+    kukit.sa.ServerAction.prototype.reallyNotifyServer = function() {
+      // make a deferred callback
+      var domDoc = new XMLHttpRequest();
+      var self = this;
+      var notifyServer_done  = function() {
+          self.notifyServer_done(domDoc);
+      };
+      // convert params
+      var query = new kukit.fo.FormQuery();
+      for (var key in this.oper.parms) {
+          query.appendElem(key, this.oper.parms[key]);
+      }
+      // also add the parms that result from submitting an entire form.
+      // This is, unlike the normal parms, is a list. Keys and values are
+      // added at the end of the query, without mangling names.
+      var submitForm = this.oper.kssParms.kssSubmitForm;
+      if (submitForm) {
+          for (var i=0; i<submitForm.length; i++) {
+              var item = submitForm[i];
+              query.appendElem(item[0], item[1]);
+          }
+      }
+      query.appendElem('_authenticator', token);
+      // encode the query
+      var encoded = query.encode();
+      // sending form
+      var ts = new Date().getTime();
+      //kukit.logDebug('TS: '+ts);
+      var tsurl = this.url + "?kukitTimeStamp=" + ts;
+      domDoc.open("POST", tsurl, true);
+      domDoc.onreadystatechange = notifyServer_done;
+      domDoc.setRequestHeader("Content-Type",
+          "application/x-www-form-urlencoded");
+      domDoc.send(encoded);
+    };
+  }
+}


### PR DESCRIPTION
This adds an `X-CSRF-TOKEN` header to ajax requests.

Fixes https://github.com/plone/plone.protect/issues/42

To make it a bit easier to test this, I have created a `sample.js` and related code on branch https://github.com/plone/plone.protect/tree/maurits-add-protect-js-sample-test-dont-merge
That branch should definitely **not** be merged. Commit https://github.com/plone/plone.protect/commit/7c8f4340290e0b23eb93f20a1d26a0f6ac62fcb5 explains it.