### PR TITLE
Removed `RedirectTo` patch.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,11 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Removed ``RedirectTo`` patch.  The patch has been merged to
+  ``Products.CMFFormController`` 3.0.7 (Plone 4.3 and 5.0) and 3.1.2
+  (Plone 5.1).  Note that we are not requiring those versions in our
+  ``setup.py``, because the code in this package no longer needs it.
+  [maurits]
 
 
 3.0.19 (2016-08-19)

--- a/plone/protect/configure.zcml
+++ b/plone/protect/configure.zcml
@@ -53,12 +53,6 @@
     <include package="collective.monkeypatcher" />
 
     <monkey:patch
-        description="Allows ATContentTypes add forms to append auth token"
-        class="Products.CMFFormController.Actions.RedirectTo.RedirectTo"
-        original="__call__"
-        replacement=".monkey.RedirectTo__call__"
-        />
-    <monkey:patch
         description="Special handling for write on read Zope2 locking issues"
         class="webdav.Lockable.LockableItem"
         original="wl_lockmapping"

--- a/plone/protect/monkey.py
+++ b/plone/protect/monkey.py
@@ -1,30 +1,6 @@
-from urlparse import urlparse, urljoin
 from plone.protect.auto import safeWrite
 import inspect
 from Products.PluggableAuthService import utils as pluggable_utils
-
-
-def RedirectTo__call__(self, controller_state):
-    url = self.getArg(controller_state)
-    context = controller_state.getContext()
-    # see if this is a relative url or an absolute
-    if len(urlparse(url)[1]) == 0:
-        # No host specified, so url is relative.  Get an absolute url.
-        url = urljoin(context.absolute_url()+'/', url)
-    url = self.updateQuery(url, controller_state.kwargs)
-    request = context.REQUEST
-    # this is mostly just for archetypes edit forms...
-    if 'edit' in url and '_authenticator' not in url and \
-            '_authenticator' in request.form:
-        if '?' in url:
-            url += '&'
-        else:
-            url += '?'
-        auth = request.form['_authenticator']
-        if isinstance(auth, list):
-            auth = auth[0]
-        url += '_authenticator=' + auth
-    return request.RESPONSE.redirect(url)
 
 
 def wl_lockmapping(self, killinvalids=0, create=0):


### PR DESCRIPTION
The patch has been merged to `Products.CMFFormController` 3.0.7 (Plone
4.3 and 5.0) and 3.1.2 (Plone 5.1).

Note that we are not requiring those versions in our `setup.py`,
because the code in this package no longer needs it.

We actually never had Products.CMFFormController in our
install_requires, so it would seem strange to begin with that now that
the code that we needed the dependency for has been removed. :-)

This pull request makes it easier/possible to properly include the 20160830 hotfix in CMFFormController itself.