### PR TITLE
Allow `confirm-action` for all contexts, instead of only Plone Site

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,14 @@ New features:
 
 Bug fixes:
 
+- Allow ``confirm-action`` for all contexts, instead of only Plone Site root.
+  This avoids an error when calling it on a subsite.
+  Fixes `issue #51 <https://github.com/plone/plone.protect/issues/51>`_.
+  [maurits]
+
 - Code Style: utf8-headers, import sorting, new style namespace declaration, autopep8
   [jensens]
+
 - Fix #57: Html must contain "body", otherwise plone.protect breaks.
   [jensens]
 

--- a/plone/protect/configure.zcml
+++ b/plone/protect/configure.zcml
@@ -42,7 +42,7 @@
 
     <browser:page
         name="confirm-action"
-        for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+        for="*"
         class=".views.ConfirmView"
         template="confirm.pt"
         permission="zope2.View"


### PR DESCRIPTION
This avoids an error when calling it on a subsite.
Fixes issue #51.