### PR TITLE
Fix logging to no longer write to stdout.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix logging to no longer write traceback to stdout, but include it in the
+  logging message instead.
+  [jone]
 
 
 3.0.24 (2017-07-03)

--- a/plone/protect/auto.py
+++ b/plone/protect/auto.py
@@ -276,7 +276,7 @@ class ProtectTransform(object):
                     logger.info(
                         '{0:s}\naborting transaction due to no CSRF '
                         'protection on url {1:s}'.format(
-                            traceback.print_stack(),
+                            '\n'.join(traceback.format_stack()),
                             self.request.URL
                         )
                     )


### PR DESCRIPTION
The `print_stack()` function does actually print the stack (to stdout), not return it. What we want to do here is use `format_stack` so that we can include the stack in the message.

```python
>>> import traceback
>>> value = traceback.print_stack()
  File "<stdin>", line 1, in <module>
>>> print value
None
>>> value = traceback.format_stack()
>>> print value
['  File "<stdin>", line 1, in <module>\n']
```