### PR TITLE
do not log a warning for empty responses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Transform does not log a warning for empty responses
+  (Fixes https://github.com/plone/plone.protect/issues/15)
+  [fRiSi]
 
 
 3.1.1 (2017-08-27)

--- a/plone/protect/auto.py
+++ b/plone/protect/auto.py
@@ -107,12 +107,10 @@ class ProtectTransform(object):
                                                    'compress',):
             return None
 
-        if isinstance(result, list):
+        if isinstance(result, list) and len(result) == 1:
             # do not parse empty strings to omit warning log message
-            if len(result) == 1:
-                if result[0].strip() == u'':
-                    return None
-
+            if not result[0].strip():
+                return None
         try:
             result = getHTMLSerializer(
                 result, pretty_print=False, encoding=encoding)
@@ -139,7 +137,6 @@ class ProtectTransform(object):
     def transformIterable(self, result, encoding):
         """Apply the transform if required
         """
-
         # before anything, do the clickjacking protection
         if (
             X_FRAME_OPTIONS and
@@ -320,6 +317,7 @@ class ProtectTransform(object):
         return True
 
     def transform(self, result, encoding):
+
         result = self.parseTree(result, encoding)
         if result is None:
             return None

--- a/plone/protect/auto.py
+++ b/plone/protect/auto.py
@@ -107,6 +107,12 @@ class ProtectTransform(object):
                                                    'compress',):
             return None
 
+        if isinstance(result, list):
+            # do not parse empty strings to omit warning log message
+            if len(result) == 1:
+                if result[0].strip() == u'':
+                    return None
+
         try:
             result = getHTMLSerializer(
                 result, pretty_print=False, encoding=encoding)


### PR DESCRIPTION
if a text/html response does not contain any data (eg empty page for an ajax request)
we do not log a warning that no csrf token could be added

this fixes #15 

not sure if the tests actually add value since i did not find a way to check no warning message is logged.
