### PR TITLE
Revert py3 changes that cause possible SyntaxError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,9 @@ Bug fixes:
 
 Bug fixes:
 
-- More Python 2 / 3 compatibility
+- More Python 2 / 3 compatibility.
+  Warning: this gives a SyntaxError on Python 2.7.8 or lower.
+  See `issue 74 <https://github.com/plone/plone.protect/issues/74>`_.
   [pbauer]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ New features:
 
 Bug fixes:
 
+- Reverted the part of the changes from 3.1.3 that introduced a possible ``SyntaxError`` on some Python 2 versions.
+  Reports are mostly for Python 2.7.8 and lower, but also one for 2.7.14, but only on Travis.
+  See `issue 74 <https://github.com/plone/plone.protect/issues/74>`_
+  and `issue 75 <https://github.com/plone/plone.protect/issues/75>`_.
+  [maurits]
+
 - Avoid CSRF warnings due to generating image scales
   stored in a plone.scale.storage.ScalesDict.
   [davisagli]

--- a/plone/protect/utils.py
+++ b/plone/protect/utils.py
@@ -61,10 +61,10 @@ class protect(object):
         facade_globs = dict(_curried=_curried, _default=_default)
         try:
             name = callable.__name__
-            exec(_buildFacade(name, spec, callable.__doc__) in facade_globs)
+            exec _buildFacade(name, spec, callable.__doc__) in facade_globs
         except TypeError:  # BBB: Zope 2.10
             name = '_facade'
-            exec(_buildFacade(spec, callable.__doc__) in facade_globs)
+            exec _buildFacade(spec, callable.__doc__) in facade_globs
         return facade_globs[name]
 
 

--- a/plone/protect/utils.py
+++ b/plone/protect/utils.py
@@ -34,7 +34,7 @@ class protect(object):
 
         arglen = len(args)
         if defaults is not None:
-            defaults = list(zip(args[arglen - len(defaults):], defaults))
+            defaults = zip(args[arglen - len(defaults):], defaults)
             arglen -= len(defaults)
 
         def _curried(*args, **kw):
@@ -59,8 +59,12 @@ class protect(object):
 
         # Build a facade, with a reference to our locally-scoped _curried
         facade_globs = dict(_curried=_curried, _default=_default)
-        name = callable.__name__
-        exec(_buildFacade(name, spec, callable.__doc__), facade_globs)
+        try:
+            name = callable.__name__
+            exec(_buildFacade(name, spec, callable.__doc__) in facade_globs)
+        except TypeError:  # BBB: Zope 2.10
+            name = '_facade'
+            exec(_buildFacade(spec, callable.__doc__) in facade_globs)
         return facade_globs[name]
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
         "Framework :: Plone :: 4.3",
         "Framework :: Plone :: 5.0",
         "Framework :: Plone :: 5.1",
-        "Framework :: Plone :: 5.2",
         "Framework :: Zope2",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
This PR is for branch 3.x that I have just created. It is used by coredev 5.0 and 5.1. With `plone4.csrffixes` it should still be fine for Plone 4.3 as well.

For info on the breakage see mostly issue #74, and a bit #75.

This PR basically reverts PR #72 on branch 3.x, except commit 7edf02d3b16e5c6b03e1288ba1cecfe9bcb4761f which seems harmless (plus the changelog entry, which should remain for historical accuracy).

The py3 changes should remain on master, used by Plone 5.2. But I hope that it can be replaced by code that looks less scary. To quote a comment from the code: "It should probably be updated to use the decorator module."