### PR TITLE
Fix package dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,17 +4,11 @@ Changelog
 3.0.27 (unreleased)
 -------------------
 
-Breaking changes:
-
-- *add item here*
-
-New features:
-
-- *add item here*
-
 Bug fixes:
 
-- *add item here*
+- Fix package dependencies;
+  ``cssselect`` has been an extra of ``lxml`` since 2014 (closes `#79 <https://github.com/plone/plone.protect/issues/79>`_).
+  [hvelarde]
 
 
 3.0.26 (2017-08-04)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
+        'lxml[cssselect]',
         'setuptools',
         'plone.keyring >= 3.0dev',
         'zope.component',


### PR DESCRIPTION
`cssselect` has been an extra of `lxml` since 2014.

https://github.com/lxml/lxml/commit/f601d017a344b337c071c9ebbcb9684e52055d59

refs, #79