### PR TITLE
Fix package dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ New features:
 
 Bug fixes:
 
+- Fix package dependencies;
+  ``cssselect`` has been an extra of ``lxml`` since 2014 (closes `#79 <https://github.com/plone/plone.protect/issues/79>`_).
+  [hvelarde]
+
 - Fixed tests to work with merged plone.login
   [jensens]
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
+        'lxml[cssselect]',
         'setuptools',
         'plone.keyring >= 3.0dev',
         'six',


### PR DESCRIPTION
`cssselect` has been an extra of `lxml` since 2014.

https://github.com/lxml/lxml/commit/f601d017a344b337c071c9ebbcb9684e52055d59

refs, #79