### PR TITLE
Remove five.globalrequest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Remove five.globalrequest dependency.
+  It has been deprecated upstream (Zope 4).
+  [gforcada]
 
 New features:
 

--- a/plone/protect/configure.zcml
+++ b/plone/protect/configure.zcml
@@ -10,7 +10,6 @@
              zcml:condition="installed AccessControl.rolemanager" />
     <include package="plone.keyring" />
     <include package="plone.transformchain" />
-    <include package="five.globalrequest" />
 
     <browser:page
        for="*"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'Zope2',
         'plone.transformchain',
         'repoze.xmliter>=0.3',
-        'five.globalrequest',
         'collective.monkeypatcher'
     ],
     extras_require={


### PR DESCRIPTION
It has been merged into Zope 4 itself.