### PR TITLE
When marking an OOBTree as safe, also mark its buckets as safe.

### DIFF
--- a/news/88.fixed
+++ b/news/88.fixed
@@ -1,0 +1,1 @@
+When marking an OOBTree as safe, also mark its buckets as safe. Fixes issues with objects that have many annotations.

--- a/plone/protect/utils.py
+++ b/plone/protect/utils.py
@@ -20,6 +20,17 @@ import logging
 
 
 SAFE_WRITE_KEY = 'plone.protect.safe_oids'
+BTREE_TYPES = (
+    IFBTree,
+    IIBTree,
+    IOBTree,
+    LFBTree,
+    LLBTree,
+    LOBTree,
+    OIBTree,
+    OLBTree,
+    OOBTree,
+)
 LOGGER = logging.getLogger('plone.protect')
 
 _default = []
@@ -131,18 +142,7 @@ def safeWrite(obj, request=None):
     try:
         if obj._p_oid not in request.environ[SAFE_WRITE_KEY]:
             request.environ[SAFE_WRITE_KEY].append(obj._p_oid)
-        btree_types = (
-            IFBTree,
-            IIBTree,
-            IOBTree,
-            LFBTree,
-            LLBTree,
-            LOBTree,
-            OIBTree,
-            OLBTree,
-            OOBTree,
-        )
-        if isinstance(obj, btree_types):
+        if isinstance(obj, BTREE_TYPES):
             bucket = obj._firstbucket
             while bucket:
                 if bucket._p_oid not in request.environ[SAFE_WRITE_KEY]:

--- a/plone/protect/utils.py
+++ b/plone/protect/utils.py
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
 from AccessControl.requestmethod import buildfacade
 from Acquisition import aq_parent
-from BTrees.OOBTree import OOBTree
+from BTrees.IFBTree import IFBTree
+from BTrees.IIBTree import IIBTree
 from BTrees.IOBTree import IOBTree
+from BTrees.LFBTree import LFBTree
+from BTrees.LLBTree import LLBTree
+from BTrees.LOBTree import LOBTree
+from BTrees.OIBTree import OIBTree
+from BTrees.OLBTree import OLBTree
+from BTrees.OOBTree import OOBTree
 from OFS.interfaces import IApplication
 from plone.keyring.keymanager import KeyManager
 from plone.protect.authenticator import createToken
@@ -124,7 +131,18 @@ def safeWrite(obj, request=None):
     try:
         if obj._p_oid not in request.environ[SAFE_WRITE_KEY]:
             request.environ[SAFE_WRITE_KEY].append(obj._p_oid)
-        if isinstance(obj, (OOBTree, IOBTree)):
+        btree_types = (
+            IFBTree,
+            IIBTree,
+            IOBTree,
+            LFBTree,
+            LLBTree,
+            LOBTree,
+            OIBTree,
+            OLBTree,
+            OOBTree,
+        )
+        if isinstance(obj, btree_types):
             bucket = obj._firstbucket
             while bucket:
                 if bucket._p_oid not in request.environ[SAFE_WRITE_KEY]:

--- a/plone/protect/utils.py
+++ b/plone/protect/utils.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from AccessControl.requestmethod import buildfacade
 from Acquisition import aq_parent
+from BTrees.OOBTree import OOBTree
+from BTrees.IOBTree import IOBTree
 from OFS.interfaces import IApplication
 from plone.keyring.keymanager import KeyManager
 from plone.protect.authenticator import createToken
@@ -122,5 +124,11 @@ def safeWrite(obj, request=None):
     try:
         if obj._p_oid not in request.environ[SAFE_WRITE_KEY]:
             request.environ[SAFE_WRITE_KEY].append(obj._p_oid)
+        if isinstance(obj, (OOBTree, IOBTree)):
+            bucket = obj._firstbucket
+            while bucket:
+                if bucket._p_oid not in request.environ[SAFE_WRITE_KEY]:
+                    request.environ[SAFE_WRITE_KEY].append(bucket._p_oid)
+                bucket = bucket._next
     except AttributeError:
         LOGGER.debug('object you attempted to mark safe does not have an oid')

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'test': [
             'plone.app.testing',
             'Products.CMFPlone'
+            'zope.annotation',
         ],
     }
 )


### PR DESCRIPTION
Fixes issues with objects that have many annotations.
Closes #88