### PR TITLE
Allow removing the `X_FRAME_OPTIONS` header or setting it from a view (fix #103)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,9 @@ override it at your proxy server, or you can set the environment variable of
 ``PLONE_X_FRAME_OPTIONS`` to whatever value you'd like plone.protect to set
 this to globally.
 
-You can opt out of this by making the environment variable empty.
+You can opt out of this by making the environment variable empty, which will
+remove the header entirely. Setting a custom value in a custom view will
+override the environment variable.
 
 
 Disable All Automatic CSRF Protection

--- a/plone/protect/auto.py
+++ b/plone/protect/auto.py
@@ -136,8 +136,17 @@ class ProtectTransform:
     def transformIterable(self, result, encoding):
         """Apply the transform if required"""
         # before anything, do the clickjacking protection
-        if X_FRAME_OPTIONS and not self.request.response.getHeader("X-Frame-Options"):
+        current_x_frame_options = self.request.response.getHeader("X-Frame-Options")
+        empty = ("", "None", None)
+
+        if X_FRAME_OPTIONS in empty and current_x_frame_options in empty:
+            self.request.response.headers.pop("x-frame-options", None)
+        elif X_FRAME_OPTIONS not in empty and current_x_frame_options is None:
+            # env var is set and header is not, set it
             self.request.response.setHeader("X-Frame-Options", X_FRAME_OPTIONS)
+        else:
+            # Header present, leave it be regardless of env var
+            assert current_x_frame_options or current_x_frame_options == ""
 
         if CSRF_DISABLED:
             return


### PR DESCRIPTION
This PR removes the `X_FRAME_OPTIONS` header when the environment variable `PLONE_X_FRAME_OPTIONS` is set to empty or `"None"`. It also respects this header's value if set by a view, and only sets it to the env var's value if it's not present beforehand.

This is my first contribution to Plone, so I apologize if the PR is wrong in any way and am ready to improve it upon request.

Fixes #103.