### PR TITLE
In login event subscriber, do not fail if request is not found. [master]

### DIFF
--- a/news/122.bugfix
+++ b/news/122.bugfix
@@ -1,0 +1,3 @@
+In login event subscriber, do not fail if request is not found.
+This probably only happens in tests, not in real world usage.
+[maurits]

--- a/plone/protect/subscribers.py
+++ b/plone/protect/subscribers.py
@@ -43,7 +43,8 @@ def onUserLogsIn(event):
     """
     # disable csrf protection on login requests
     req = getRequest()
-    alsoProvides(req, IDisableCSRFProtection)
+    if req:
+        alsoProvides(req, IDisableCSRFProtection)
 
     try:
         manager = getUtility(IKeyManager)


### PR DESCRIPTION
A few lines further we already have a check `if req:`, so this should already have been done here as well.

This probably only happens in tests, not in real world usage.

This is needed for an upcoming change in PAS.
See https://github.com/zopefoundation/Products.PluggableAuthService/pull/122#issuecomment-2791286070

Forward port of PR #128.