### PR TITLE
Strict protection on the confirm-action view

### DIFF
--- a/news/131.bugfix.rxt
+++ b/news/131.bugfix.rxt
@@ -1,0 +1,1 @@
+Do not allow the confirm-action view to be called without a valid authenticator. [ale-rt]

--- a/plone/protect/auto.py
+++ b/plone/protect/auto.py
@@ -301,6 +301,10 @@ class ProtectTransform:
                     if self.site and (resp.status in (301, 302) or "text/html" in ct):
                         data = self.request.form.copy()
                         data["original_url"] = self.request.URL
+                        # NOTE: self.key_manager is initialized in the transformIterable
+                        # method, which calls the check method and thus this
+                        # _check method.
+                        data["_authenticator"] = createToken(manager=self.key_manager)
                         resp.redirect(
                             "{}/@@confirm-action?{}".format(
                                 self.site.absolute_url(), urlencode(data)

--- a/plone/protect/tests/test_confirm_view.py
+++ b/plone/protect/tests/test_confirm_view.py
@@ -1,3 +1,4 @@
+from plone.protect.authenticator import createToken
 from plone.protect.testing import PROTECT_FUNCTIONAL_TESTING
 from zExceptions import Forbidden
 from zope.component import getMultiAdapter
@@ -12,12 +13,26 @@ class TestAttackVector(unittest.TestCase):
         portal = self.layer["portal"]
         request = self.layer["request"]
         view = getMultiAdapter((portal, request), name="confirm-action")
-        request.form.update({"original_url": "foobar"})
+        request.form.update({"original_url": "foobar", "_authenticator": createToken()})
         self.assertTrue('value="foobar"' in view())
 
     def test_valid_url(self):
         portal = self.layer["portal"]
         request = self.layer["request"]
         view = getMultiAdapter((portal, request), name="confirm-action")
-        request.form.update({"original_url": "javascript:alert(1)"})
+        request.form.update(
+            {"original_url": "javascript:alert(1)", "_authenticator": createToken()}
+        )
         self.assertRaises(Forbidden, view)
+
+    def test_valid_authenticator(self):
+        portal = self.layer["portal"]
+        request = self.layer["request"]
+        view = getMultiAdapter((portal, request), name="confirm-action")
+        request.form.update(
+            {"original_url": portal.absolute_url(), "_authenticator": "foobar"}
+        )
+
+        with self.assertRaises(Forbidden) as cm:
+            view()
+        self.assertEqual(str(cm.exception), "Form authenticator is invalid.")

--- a/plone/protect/views.py
+++ b/plone/protect/views.py
@@ -1,3 +1,4 @@
+from plone.protect.authenticator import check
 from plone.protect.interfaces import IConfirmView
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
@@ -7,7 +8,9 @@ from zope.interface import implementer
 
 @implementer(IConfirmView)
 class ConfirmView(BrowserView):
+
     def __call__(self):
+        check(self.request)
         urltool = getToolByName(self.context, "portal_url")
         original_url = getattr(self.request, "original_url", "")
         if not original_url or not urltool.isURLInPortal(original_url):


### PR DESCRIPTION
Do not allow the confirm-action view to be called without a valid authenticator.